### PR TITLE
Simplify splitEnv

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -11,6 +11,6 @@ func CurrentEnv() map[string]string {
 
 // Env translates the provided environment to a map[string]string.
 func Env(env []string) map[string]string {
-	vars := mapEnv(env, splitEnv())
+	vars := mapEnv(env, splitEnv)
 	return vars
 }

--- a/envmap.go
+++ b/envmap.go
@@ -2,13 +2,12 @@ package cfenv
 
 import "strings"
 
-func splitEnv() func(item string) (key, val string) {
-	return func(item string) (key, val string) {
-		splits := strings.Split(item, "=")
-		key = splits[0]
-		val = strings.Join(splits[1:], "=")
-		return
-	}
+// splitEnv splits item, a key=value string, into its key and value components.
+func splitEnv(item string) (key, val string) {
+	splits := strings.Split(item, "=")
+	key = splits[0]
+	val = strings.Join(splits[1:], "=")
+	return
 }
 
 func mapEnv(data []string, keyFunc func(item string) (key, val string)) map[string]string {

--- a/envmap_test.go
+++ b/envmap_test.go
@@ -8,11 +8,16 @@ import (
 var _ = Describe("Envmap", func() {
 	Describe("Environment variables should be split correctly", func() {
 		test := func(input string, expectedKey string, expectedValue string) {
-			split := splitEnv()
-			k, v := split(input)
+			k, v := splitEnv(input)
 			Ω(k).Should(Equal(expectedKey))
 			Ω(v).Should(Equal(expectedValue))
 		}
+
+		Context("With empty env var", func() {
+			It("Should have empty value", func() {
+				test("", "", "")
+			})
+		})
 
 		Context("With env var not split by equals", func() {
 			It("Should have empty value", func() {


### PR DESCRIPTION
Rather than splitEnv returning a function for use with mapEnv, alter the
signature of splitEnv so it can be used directly as a split function
with mapEnv.

Also, add a test case for splitting an empty value.