### PR TITLE
Add CredentialString

### DIFF
--- a/cfenv_test.go
+++ b/cfenv_test.go
@@ -276,4 +276,32 @@ var _ = Describe("Cfenv", func() {
 			})
 		})
 	})
+
+	Describe("CredentialString", func() {
+		var service = Service{
+			Credentials: map[string]interface{}{
+				"string": "stringy-credential",
+				"int":    42,
+				"nested": map[string]string{
+					"key": "value",
+				},
+			},
+		}
+
+		It("returns the requested credential as a string when the credential is a string", func() {
+			result, ok := service.CredentialString("string")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal("stringy-credential"))
+		})
+
+		It("returns false when the credential is not a string", func() {
+			_, ok := service.CredentialString("int")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("returns false when the credential is a nested thing", func() {
+			_, ok := service.CredentialString("nested")
+			Expect(ok).To(BeFalse())
+		})
+	})
 })

--- a/service.go
+++ b/service.go
@@ -2,8 +2,8 @@ package cfenv
 
 import (
 	"fmt"
-	"strings"
 	"regexp"
+	"strings"
 )
 
 // Service describes a bound service. For bindable services Cloud Foundry will
@@ -21,6 +21,11 @@ type Service struct {
 	Tags        []string               // tags for the service
 	Plan        string                 // plan of the service
 	Credentials map[string]interface{} // credentials for the service
+}
+
+func (s *Service) CredentialString(key string) (string, bool) {
+	credential, ok := s.Credentials[key].(string)
+	return credential, ok
 }
 
 // Services is an association of service labels to a slice of services with that
@@ -48,6 +53,7 @@ func (s *Services) WithTag(tag string) ([]Service, error) {
 
 	return nil, fmt.Errorf("no services with tag %s", tag)
 }
+
 // WithTag finds services with a tag pattern.
 func (s *Services) WithTagUsingPattern(tagPattern string) ([]Service, error) {
 	result := []Service{}


### PR DESCRIPTION
CredentialString is a helper to return you the credential under the
given key as a string, if indeed it is a string.

Signed-off-by: Joe Fitzgerald <jfitzgerald@pivotal.io>