### PR TITLE
adding application ID, clarifying instance vs. app ID

### DIFF
--- a/application.go
+++ b/application.go
@@ -2,7 +2,9 @@ package cfenv
 
 // An App holds information about the current app running on Cloud Foundry
 type App struct {
-	ID              string   `json:"instance_id"`      // id of the app
+	ID              string   `json:"-"`                // DEPRECATED id of the instance
+	InstanceID      string   `json:"instance_id"`      // id of the instance
+	AppID           string   `json:"application_id"`   // id of the application
 	Index           int      `json:"instance_index"`   // index of the app
 	Name            string   `json:"name"`             // name of the app
 	Host            string   `json:"host"`             // host of the app
@@ -17,4 +19,12 @@ type App struct {
 	TempDir         string   // directory location where temporary and staging files are stored
 	User            string   // user account under which the DEA runs
 	Services        Services // services bound to the app
+	CFAPI           string   `json:"cf_api"` // URL for the Cloud Foundry API endpoint
+	Limits          *Limits  `json:"limits"` // limits imposed on this process
+}
+
+type Limits struct {
+	Disk int `json:"disk"` // disk limit
+	FDs  int `json:"fds"`  // file descriptors limit
+	Mem  int `json:"mem"`  // memory limit
 }

--- a/cfenv.go
+++ b/cfenv.go
@@ -14,6 +14,10 @@ func New(env map[string]string) (*App, error) {
 	if err := json.Unmarshal([]byte(appVar), &app); err != nil {
 		return nil, err
 	}
+	// duplicate the InstanceID to the previously named ID field for backwards
+	// compatibility
+	app.ID = app.InstanceID
+
 	app.Home = env["HOME"]
 	app.MemoryLimit = env["MEMORY_LIMIT"]
 	app.WorkingDir = env["PWD"]

--- a/cfenv_test.go
+++ b/cfenv_test.go
@@ -10,7 +10,7 @@ import (
 var _ = Describe("Cfenv", func() {
 	Describe("Application deserialization", func() {
 		validEnv := []string{
-			`VCAP_APPLICATION={"instance_id":"451f045fd16427bb99c895a2649b7b2a","instance_index":0,"host":"0.0.0.0","port":61857,"started_at":"2013-08-12 00:05:29 +0000","started_at_timestamp":1376265929,"start":"2013-08-12 00:05:29 +0000","state_timestamp":1376265929,"limits":{"mem":512,"disk":1024,"fds":16384},"application_version":"c1063c1c-40b9-434e-a797-db240b587d32","application_name":"styx-james","application_uris":["styx-james.a1-app.cf-app.com"],"version":"c1063c1c-40b9-434e-a797-db240b587d32","name":"styx-james","space_id":"3e0c28c5-6d9c-436b-b9ee-1f4326e54d05","space_name":"jdk","uris":["styx-james.a1-app.cf-app.com"],"users":null}`,
+			`VCAP_APPLICATION={"instance_id":"451f045fd16427bb99c895a2649b7b2a","application_id":"abcabc123123defdef456456","cf_api": "https://api.system_domain.com","instance_index":0,"host":"0.0.0.0","port":61857,"started_at":"2013-08-12 00:05:29 +0000","started_at_timestamp":1376265929,"start":"2013-08-12 00:05:29 +0000","state_timestamp":1376265929,"limits":{"mem":512,"disk":1024,"fds":16384},"application_version":"c1063c1c-40b9-434e-a797-db240b587d32","application_name":"styx-james","application_uris":["styx-james.a1-app.cf-app.com"],"version":"c1063c1c-40b9-434e-a797-db240b587d32","name":"styx-james","space_id":"3e0c28c5-6d9c-436b-b9ee-1f4326e54d05","space_name":"jdk","uris":["styx-james.a1-app.cf-app.com"],"users":null}`,
 			`HOME=/home/vcap/app`,
 			`MEMORY_LIMIT=512m`,
 			`PWD=/home/vcap`,
@@ -20,7 +20,7 @@ var _ = Describe("Cfenv", func() {
 		}
 
 		validEnvWithoutSpaceIDAndName := []string{
-			`VCAP_APPLICATION={"instance_id":"451f045fd16427bb99c895a2649b7b2a","instance_index":0,"host":"0.0.0.0","port":61857,"started_at":"2013-08-12 00:05:29 +0000","started_at_timestamp":1376265929,"start":"2013-08-12 00:05:29 +0000","state_timestamp":1376265929,"limits":{"mem":512,"disk":1024,"fds":16384},"application_version":"c1063c1c-40b9-434e-a797-db240b587d32","application_name":"styx-james","application_uris":["styx-james.a1-app.cf-app.com"],"version":"c1063c1c-40b9-434e-a797-db240b587d32","name":"styx-james","uris":["styx-james.a1-app.cf-app.com"],"users":null}`,
+			`VCAP_APPLICATION={"instance_id":"451f045fd16427bb99c895a2649b7b2a","application_id":"abcabc123123defdef456456","cf_api": "https://api.system_domain.com","instance_index":0,"host":"0.0.0.0","port":61857,"started_at":"2013-08-12 00:05:29 +0000","started_at_timestamp":1376265929,"start":"2013-08-12 00:05:29 +0000","state_timestamp":1376265929,"limits":{"mem":512,"disk":1024,"fds":16384},"application_version":"c1063c1c-40b9-434e-a797-db240b587d32","application_name":"styx-james","application_uris":["styx-james.a1-app.cf-app.com"],"version":"c1063c1c-40b9-434e-a797-db240b587d32","name":"styx-james","uris":["styx-james.a1-app.cf-app.com"],"users":null}`,
 			`HOME=/home/vcap/app`,
 			`MEMORY_LIMIT=512m`,
 			`PWD=/home/vcap`,
@@ -30,7 +30,7 @@ var _ = Describe("Cfenv", func() {
 		}
 
 		envWithIntCredentials := []string{
-			`VCAP_APPLICATION={"instance_id":"451f045fd16427bb99c895a2649b7b2a","instance_index":0,"host":"0.0.0.0","port":61857,"started_at":"2013-08-12 00:05:29 +0000","started_at_timestamp":1376265929,"start":"2013-08-12 00:05:29 +0000","state_timestamp":1376265929,"limits":{"mem":512,"disk":1024,"fds":16384},"application_version":"c1063c1c-40b9-434e-a797-db240b587d32","application_name":"styx-james","application_uris":["styx-james.a1-app.cf-app.com"],"version":"c1063c1c-40b9-434e-a797-db240b587d32","name":"styx-james","uris":["styx-james.a1-app.cf-app.com"],"users":null}`,
+			`VCAP_APPLICATION={"instance_id":"451f045fd16427bb99c895a2649b7b2a","application_id":"abcabc123123defdef456456","cf_api": "https://api.system_domain.com","instance_index":0,"host":"0.0.0.0","port":61857,"started_at":"2013-08-12 00:05:29 +0000","started_at_timestamp":1376265929,"start":"2013-08-12 00:05:29 +0000","state_timestamp":1376265929,"limits":{"mem":512,"disk":1024,"fds":16384},"application_version":"c1063c1c-40b9-434e-a797-db240b587d32","application_name":"styx-james","application_uris":["styx-james.a1-app.cf-app.com"],"version":"c1063c1c-40b9-434e-a797-db240b587d32","name":"styx-james","uris":["styx-james.a1-app.cf-app.com"],"users":null}`,
 			`HOME=/home/vcap/app`,
 			`MEMORY_LIMIT=512m`,
 			`PWD=/home/vcap`,
@@ -62,6 +62,9 @@ var _ = Describe("Cfenv", func() {
 				Ω(cfenv).ShouldNot(BeNil())
 
 				Ω(cfenv.ID).Should(BeEquivalentTo("451f045fd16427bb99c895a2649b7b2a"))
+				Ω(cfenv.InstanceID).Should(BeEquivalentTo("451f045fd16427bb99c895a2649b7b2a"))
+				Ω(cfenv.AppID).Should(BeEquivalentTo("abcabc123123defdef456456"))
+				Ω(cfenv.CFAPI).Should(BeEquivalentTo("https://api.system_domain.com"))
 				Ω(cfenv.Index).Should(BeEquivalentTo(0))
 				Ω(cfenv.Name).Should(BeEquivalentTo("styx-james"))
 				Ω(cfenv.SpaceName).Should(BeEquivalentTo("jdk"))
@@ -74,6 +77,9 @@ var _ = Describe("Cfenv", func() {
 				Ω(cfenv.WorkingDir).Should(BeEquivalentTo("/home/vcap"))
 				Ω(cfenv.TempDir).Should(BeEquivalentTo("/home/vcap/tmp"))
 				Ω(cfenv.User).Should(BeEquivalentTo("vcap"))
+				Ω(cfenv.Limits.Disk).Should(BeEquivalentTo(1024))
+				Ω(cfenv.Limits.Mem).Should(BeEquivalentTo(512))
+				Ω(cfenv.Limits.FDs).Should(BeEquivalentTo(16384))
 				Ω(cfenv.ApplicationURIs[0]).Should(BeEquivalentTo("styx-james.a1-app.cf-app.com"))
 				Ω(len(cfenv.Services)).Should(BeEquivalentTo(2))
 				Ω(cfenv.Services["elephantsql-dev"][0].Name).Should(BeEquivalentTo("elephantsql-dev-c6c60"))


### PR DESCRIPTION
Instance ID changes with every push, application ID remains the same.  Adding Application ID to the package so that it is accessible to the launched service.  
Because ID is not clear whether it's the instance or application ID, I have added a new key Instance ID and duplicated its value to the ID field, marking the ID field as deprecated.  ID will continue to work as it has, but using Instance ID is preferred to differentiate it from Application ID.

While I'm in here, adding some structure to the existing Limits sub-map ad adding the Cloud Foundry API URL, which is also present in the current environment.