### PR TITLE
Fix Scorecard, add community health files and badges (v1.19.1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
 updates:
-  # Go modules. Note: x/net and x/text are deliberately pinned to their
-  # newest go1.18-compatible releases. Reject Dependabot PRs that move
-  # them past x/net v0.35.0 or x/text v0.22.0 until the go directive is
-  # raised, since newer releases require go 1.23.
+  # Go modules. Several dependencies are deliberately held at their newest
+  # go1.18-compatible release. Reject Dependabot PRs that move them until
+  # the go directive is raised:
+  #
+  #   golang.org/x/net    v0.35.0   - newer requires go 1.23
+  #   golang.org/x/text   v0.22.0   - newer requires go 1.23
+  #   github.com/onsi/gomega v1.27.10 - newer requires go 1.25
+  #
+  # gomega is the trap: it is a direct requirement, so Dependabot proposes
+  # major jumps that look routine. v1.42.1 declares `go 1.25.0` and would
+  # silently break the declared 1.18 floor.
   - package-ecosystem: gomod
     directory: "/"
     schedule:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        # Pinned to a full patch tag: this action publishes no floating `v2`
+        # major tag, so `@v2` fails to resolve and the workflow never runs.
+        uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# v1.19.1
+
+No code changes. This release is repository and supply-chain tooling only;
+the library is byte-for-byte identical to v1.19.0.
+
+# Internal Changes/Improvements
+
+* OpenSSF Scorecard now actually runs.
+
+  The workflow referenced `ossf/scorecard-action@v2`. That action publishes
+  no floating major tag, so the reference never resolved and every run since
+  the workflow was added failed before starting — nothing was ever uploaded
+  to the code-scanning tab. Pinned to v2.4.4.
+
+* Dependabot's pinned-dependency guard now covers gomega.
+
+  It documented the x/net and x/text pins but omitted onsi/gomega, which is
+  held at v1.27.10 as the newest go1.18-compatible release. Dependabot duly
+  proposed v1.42.1, which declares `go 1.25.0` and would have broken the
+  declared floor.
+
+* Added CODE_OF_CONDUCT.md, CONTRIBUTING.md and SECURITY.md, taken from the
+  cloudfoundry and cloudfoundry-community org sources, so this repo points at
+  the same CFF vulnerability reporting address and CLA process as the rest of
+  the org.
+
+* README carries CI, CodeQL, Scorecard, Go version, release and license
+  badges. The Go Reference badge is removed. Go Report Card is deliberately
+  absent: that project is archived read-only and its site now serves only a
+  shutdown notice.
+
+# Compatibility
+
+No public API changes, and no changes to any `.go` file, `go.mod` or
+`go.sum`. Consumers have no reason to upgrade from v1.19.0.
+
+---
+
 # v1.19.0
 
 # Breaking Changes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Code of Conduct
+
+To ensure we maintain a welcome and thriving environment to collaborate we’ve come up with some general guidelines that apply to participants in the Cloud Foundry community.
+
+This markdown file is taken from the [online code of conduct](https://www.cloudfoundry.org/code-of-conduct/). If deviations occur, please alert the project and consider the online version to be the correct source.
+
+## Guidelines
+
+**Act Professionally**: Be courteous, respectful and polite to fellow community members: no racial, gender, or other abuse will be tolerated.
+
+**We value diversity and inclusiveness**: Make everyone in our community feel welcome, regardless of their background and the extent of their contributions, and do everything possible to encourage participation in our community. We do not tolerate exclusionary behavior.
+
+**Be careful in the words that we choose**: Whether we are participating as professionals or volunteers, we value professionalism in all interactions, and take responsibility for our own speech. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior are not acceptable. This includes, but is not limited to:
+
+- Violent threats or language directed against another person.
+- Sexist, racist, or otherwise discriminatory jokes and language.
+- Posting sexually explicit or violent material.
+- Posting (or threatening to post) other people’s personally identifying information (“doxing”).
+- Sharing private content without prior consent, such as emails sent privately or non-publicly, or unlogged forums such as private IMs.
+- Personal insults, especially those using racist or sexist terms.
+- Unwelcome sexual attention.
+- Bullying or repeated harassment of others. In general, if someone asks you to stop, then stop.
+- Advocating for, staying silent about, not reporting, or encouraging, any of the above behavior.
+
+**Keep it legal**: Share only content that you own, do not share private or sensitive information, and do not break the law.
+
+**Stay on topic**: Make sure that you are posting to the correct channel and avoid off-topic discussions. Remember when you update an issue or respond to an email you are potentially sending to a large number of people.
+
+**Respect all Cloud Foundry community forums**: The previous list applies to all forms of interaction including, but not limited to: participation in the Dojos, social media such as Twitter, IRC, the mailing lists, the issue tracker, review comments, and any other forum that is used by the community. Events that take place in public spaces, such as conferences and meetup groups, will generally have their own code of conduct or similar community guidelines. As such, the guidelines for a specific event should be followed.
+
+**Step down considerately**: Members of every project come and go, and Cloud Foundry is no different. When somebody leaves or disengages from the project, in whole or in part, we ask that they do so in a way that minimizes disruption to the project. This means they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
+
+**Keep in mind**: Your work will be used by other people, and you, in turn, will depend on the work of others.
+
+Decisions that you make will often affect others in the community.
+
+Disagreements happen, but should not be an excuse for poor behavior and bad manners. When disagreements do happen, work together to solve them effectively and with comity.
+
+People may not understand jokes, sarcasm, and oblique references in the same way that you do. So remember that and be kind to the other members of the community.
+
+Sexist, racist, and other prejudicial or exclusionary comments are not welcome in the community.
+
+You are participating in an open source software project of a global scope. Please keep in mind how words, the tone of statements and sarcasm may be interpreted (or misinterpreted) by others.
+
+## Report an Incident
+
+To report incidents or to appeal reports of incidents, send an email to [conduct@cloudfoundry.org](mailto:conduct@cloudfoundry.org). Please include any available relevant information, including links to any publicly accessible material relating to the matter. Every effort will be taken to ensure a safe and collegial environment in which to collaborate on matters relating to the Foundation. In order to protect the community, the Foundation reserves the right to take appropriate action, potentially including the removal of an individual from any and all participation in the project. The Foundation will work towards an equitable resolution in the event of a misunderstanding.
+
+## Credits
+
+This code of conduct is based on the example policy from the Geek Feminism wiki, created by the Ada Initiative and other volunteers, as well as several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work. Additional thanks to the Ubuntu, Chef, Puppet, Docker, CouchDB and OpenStack communities for providing inspiration for these guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Thank you for your interest in contributing to Cloud Foundry
+
+We try to tag issues that should be reasonable for a new contributor to take on with a [good first issue](https://github.com/search?q=org%3Acloudfoundry+org%3Acommunity+label%3A%22good+first+issue%22+state%3Aopen&type=Issues) label so you have somewhere to start. 
+
+**How to contribute:**
+- Fork the repo you'd like to make a contribution to
+- Clone your fork to your local workstation
+- Create a new branch for the issue
+- Make the necessary changes on that branch
+- Commit and push to that branch
+- Make a Pull Request against the repo
+- Sign the Contributor Licensing Agreement, if you haven’t already
+
+All committers to a Cloud Foundry Foundation project must sign a Contributor License Agreement. 
+To sign these documents and begin contributing, please [sign in to the EasyCLA app](https://corporate.v1.easycla.lfx.linuxfoundation.org/). 
+Or, you’ll simply be prompted to do so when you put in your first Pull Request.
+
+If you’d like to have someone review the agreement before signing, you may download them here: 
+- [Individual Contributor License Agreement](https://www.cloudfoundry.org/wp-content/uploads/icla.pdf)
+- [Corporate Contributor License Agreement](https://www.cloudfoundry.org/wp-content/uploads/ccla.pdf)
+
+**Where can I reach out to the team?**
+
+- _Want to report concerns/bugs?_ Create an issue on the affected repo.
+- _Usage issues/help?_ Reach out to us on [Slack](https://slack.cloudfoundry.org/) or our [cf-dev mailing list](https://lists.cloudfoundry.org/g/cf-dev/topics).
+- _Want to participate in deeper architectural discussions?_ Attend a relevant [working group meeting](https://github.com/cloudfoundry/community/blob/main/toc/working-groups/WORKING-GROUPS.md) or our monthly CAB call. 
+
+You’ll find these listed on our [community calendar](https://www.cloudfoundry.org/community-calendar/).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Go CF Environment Package [![CI](https://github.com/cloudfoundry-community/go-cfenv/actions/workflows/ci.yml/badge.svg)](https://github.com/cloudfoundry-community/go-cfenv/actions/workflows/ci.yml)
+# Go CF Environment Package
+
+[![CI](https://github.com/cloudfoundry-community/go-cfenv/actions/workflows/ci.yml/badge.svg)](https://github.com/cloudfoundry-community/go-cfenv/actions/workflows/ci.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/cloudfoundry-community/go-cfenv/codeql.yml?label=CodeQL)](https://github.com/cloudfoundry-community/go-cfenv/security/code-scanning)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cloudfoundry-community/go-cfenv/badge)](https://scorecard.dev/viewer/?uri=github.com/cloudfoundry-community/go-cfenv)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/cloudfoundry-community/go-cfenv)](go.mod)
+[![Latest Release](https://img.shields.io/github/v/release/cloudfoundry-community/go-cfenv)](https://github.com/cloudfoundry-community/go-cfenv/releases)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 ### Overview
-
-[![Go Reference](https://pkg.go.dev/badge/github.com/cloudfoundry-community/go-cfenv.svg)](https://pkg.go.dev/github.com/cloudfoundry-community/go-cfenv)
 
 `cfenv` is a package to assist you in writing Go apps that run on [Cloud Foundry](http://cloudfoundry.org). It provides convenience functions and structures that map to Cloud Foundry environment variable primitives (http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+The Cloud Foundry Foundation (CFF) Security Team provides a single point of contact for the reporting of security vulnerabilities in open source Cloud Foundry codebases and coordinates the process of investigating any reports. Please see [this page](https://cve.mitre.org/about/terminology.html) for more information about what might qualify as a vulnerability.
+
+## Reporting a Vulnerability
+
+We strongly encourage people to report security vulnerabilities privately to our security team before disclosing them in a public forum.
+
+The e-mail address to use to contact the CFF Security Team is **security@cloudfoundry.org**.
+
+Please note that the e-mail address above should only be used for reporting undisclosed security vulnerabilities in open source Cloud Foundry codebases and managing the process of fixing such vulnerabilities. We cannot accept regular bug reports or other security-related queries at this address.
+
+If you wish to send encrypted email, our public key can be obtained from a public key server such as keys.openpgp.org. The fingerprint is: `3FC8 9AF3 940B E270 CF25  E122 9965 0006 EF9D C642`


### PR DESCRIPTION
Tooling-only follow-up to v1.19.0. **No `.go`, `go.mod` or `go.sum` changes** —
the library is byte-for-byte identical to v1.19.0 and consumers have no reason
to upgrade. Released as v1.19.1 so the repository state is tagged.

### OpenSSF Scorecard has never run

The workflow referenced `ossf/scorecard-action@v2`. That action publishes only
patch tags — there is no floating `v2` major tag and no `v2` branch — so the
reference never resolved:

```
##[error]Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```

Every run since the workflow was added failed before starting, and nothing was
ever uploaded to the code-scanning tab. Pinned to `v2.4.4`. The other four
action references were checked and all resolve.

### Dependabot's guard missed gomega

`dependabot.yml` documented the `x/net` and `x/text` pins but omitted
`onsi/gomega`, which is held at v1.27.10 as the newest go1.18-compatible
release. Dependabot has already proposed v1.42.1 (#30), which declares
`go 1.25.0` and would silently break the declared 1.18 floor. The guard now
lists all three.

### Community health files

`CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` are taken verbatim from
`cloudfoundry/community`, `SECURITY.md` from `cloudfoundry/.github`, so this
repo points at the same CFF vulnerability reporting address
(security@cloudfoundry.org) and EasyCLA process as the rest of the org. They
also raise the Scorecard score the new badge reports.

### Badges

CI, CodeQL, OpenSSF Scorecard, Go version, latest release, and license.

Two deliberate omissions:
- **Go Reference** removed.
- **Go Report Card** not added — [gojp/goreportcard](https://github.com/gojp/goreportcard)
  is archived read-only and goreportcard.com now serves only a shutdown
  notice, though it still answers HTTP 200.

The Scorecard badge will read as unknown until this merges and the fixed
workflow runs on `master`.
