### PR TITLE
Reach nested credentials, and lint workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
           version: latest
           args: --timeout=5m
       - run: make fmt vet tidy
+      # These workflow files are the one thing here that CI cannot catch by
+      # failing: a bad action ref or a duplicate key breaks the run itself.
+      # `make check` includes this, but this job runs the gates individually
+      # because golangci-lint comes from the action above rather than `make
+      # lint` — so actionlint has to be listed here too.
+      - run: make actionlint
       # Catches a stub or malformed release-notes fragment before it can
       # silently drop out of the assembled notes at release time.
       - run: make changelog-check

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,18 @@ lint: ## Run golangci-lint
 	  echo "golangci-lint not found. See https://golangci-lint.run/welcome/install/"; exit 1; }
 	golangci-lint run ./...
 
+# Workflow files are executable configuration, and YAML validity says
+# nothing about whether they work: an action ref that never resolves and a
+# duplicate env: key that stopped the whole workflow from parsing both
+# shipped past review. actionlint catches that class.
+.PHONY: actionlint
+actionlint: ## Lint GitHub Actions workflow files
+	@command -v actionlint >/dev/null 2>&1 || { \
+	  echo "Installing actionlint..."; \
+	  go install github.com/rhysd/actionlint/cmd/actionlint@latest; \
+	}
+	actionlint
+
 .PHONY: tidy
 tidy: ## Fail if go mod tidy would change anything
 	@cp go.mod go.mod.bak; cp go.sum go.sum.bak
@@ -71,7 +83,7 @@ tidy: ## Fail if go mod tidy would change anything
 	@rm -f go.mod.bak go.sum.bak
 
 .PHONY: check
-check: fmt vet lint tidy ## Run all quality gates
+check: fmt vet lint actionlint tidy ## Run all quality gates
 
 ##@ Security
 

--- a/cfenv_test.go
+++ b/cfenv_test.go
@@ -373,4 +373,168 @@ func testcfenv(t *testing.T, when spec.G, it spec.S) {
 			Expect(ok).To(BeFalse())
 		})
 	})
+
+	// Issue #11: a credential whose value was a nested object once panicked
+	// the decoder, which expected every credential to be a string. Pins the
+	// payload from that report so the fix cannot silently regress.
+	when("credentials containing nested objects", func() {
+		it("decodes them and leaves the nested object reachable", func() {
+			env, err := cfenv.New(map[string]string{
+				"VCAP_APPLICATION": "{}",
+				"VCAP_SERVICES": `{"redis-lite":[{
+					"credentials":{
+						"hostname":"10.10.10.1",
+						"password":"abc",
+						"port":"32843",
+						"ports":{"6379/tcp":"32843"}
+					},
+					"label":"redis-lite",
+					"name":"uptime-redis",
+					"plan":"free",
+					"tags":["redis28","redis","key-value"]
+				}]}`,
+			})
+			Expect(err).To(BeNil())
+
+			service, err := env.Services.WithName("uptime-redis")
+			Expect(err).To(BeNil())
+
+			port, ok := service.Credential("ports", "6379/tcp")
+			Expect(ok).To(BeTrue())
+			Expect(port).To(Equal("32843"))
+		})
+	})
+
+	when("Credential", func() {
+		// Mirrors what cfenv.New produces: nested objects decode to
+		// map[string]interface{} and leaves keep their JSON types.
+		var service = cfenv.Service{
+			Credentials: map[string]interface{}{
+				"uri": "amqp://guest@rabbitmq:5672",
+				"protocols": map[string]interface{}{
+					"amqp": map[string]interface{}{
+						"uri":  "amqp://guest:guest@rabbitmq:5672",
+						"ssl":  false,
+						"port": float64(5672),
+					},
+				},
+				"hosts": []interface{}{"a", "b"},
+				// A real credential key that contains a dot.
+				"jdbc.url": "jdbc:mysql://x",
+			},
+		}
+
+		it("returns a top-level credential", func() {
+			result, ok := service.Credential("uri")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal("amqp://guest@rabbitmq:5672"))
+		})
+
+		it("returns a credential nested several levels deep", func() {
+			result, ok := service.Credential("protocols", "amqp", "uri")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal("amqp://guest:guest@rabbitmq:5672"))
+		})
+
+		it("returns a non-string leaf with its own type", func() {
+			result, ok := service.Credential("protocols", "amqp", "ssl")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal(false))
+
+			result, ok = service.Credential("protocols", "amqp", "port")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal(float64(5672)))
+		})
+
+		it("returns an intermediate map when the path stops there", func() {
+			result, ok := service.Credential("protocols", "amqp")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(HaveKeyWithValue("uri", "amqp://guest:guest@rabbitmq:5672"))
+		})
+
+		it("returns a slice leaf", func() {
+			result, ok := service.Credential("hosts")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal([]interface{}{"a", "b"}))
+		})
+
+		it("addresses a key containing a dot", func() {
+			result, ok := service.Credential("jdbc.url")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal("jdbc:mysql://x"))
+		})
+
+		it("returns false when a top-level key is missing", func() {
+			_, ok := service.Credential("nope")
+			Expect(ok).To(BeFalse())
+		})
+
+		it("returns false when a nested key is missing", func() {
+			_, ok := service.Credential("protocols", "amqp", "nope")
+			Expect(ok).To(BeFalse())
+		})
+
+		it("returns false when descending through a non-map", func() {
+			_, ok := service.Credential("uri", "nope")
+			Expect(ok).To(BeFalse())
+		})
+
+		it("returns false when given no keys", func() {
+			_, ok := service.Credential()
+			Expect(ok).To(BeFalse())
+		})
+
+		it("returns false when the credentials are empty", func() {
+			empty := cfenv.Service{}
+			_, ok := empty.Credential("uri")
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	when("CredentialPath", func() {
+		var service = cfenv.Service{
+			Credentials: map[string]interface{}{
+				"protocols": map[string]interface{}{
+					"amqp": map[string]interface{}{
+						"uri": "amqp://guest:guest@rabbitmq:5672",
+						"ssl": false,
+					},
+				},
+				"jdbc.url": "jdbc:mysql://x",
+			},
+		}
+
+		it("returns a credential addressed by a dotted path", func() {
+			result, ok := service.CredentialPath("protocols.amqp.uri")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal("amqp://guest:guest@rabbitmq:5672"))
+		})
+
+		it("returns a non-string leaf with its own type", func() {
+			result, ok := service.CredentialPath("protocols.amqp.ssl")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal(false))
+		})
+
+		it("returns false for a missing path", func() {
+			_, ok := service.CredentialPath("protocols.stomp.uri")
+			Expect(ok).To(BeFalse())
+		})
+
+		it("returns false for an empty path", func() {
+			_, ok := service.CredentialPath("")
+			Expect(ok).To(BeFalse())
+		})
+
+		// The documented limitation of the dotted form: a key containing a
+		// dot is split and becomes unreachable. Credential addresses it.
+		it("cannot address a key containing a dot", func() {
+			_, ok := service.CredentialPath("jdbc.url")
+			Expect(ok).To(BeFalse())
+
+			result, ok := service.Credential("jdbc.url")
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal("jdbc:mysql://x"))
+		})
+	})
 }

--- a/changelog.d/0002-add-actionlint-target.md
+++ b/changelog.d/0002-add-actionlint-target.md
@@ -1,0 +1,2 @@
+[Chores]
+- Added a `make actionlint` target that lints the GitHub Actions workflow files, auto-installing actionlint on demand. It is part of `make check` and runs as its own step in the CI quality-gates job.

--- a/changelog.d/0003-nested-credentials.md
+++ b/changelog.d/0003-nested-credentials.md
@@ -1,0 +1,6 @@
+[Features]
+- `Service.Credential(keys ...string)` reads a credential at any depth and returns it with its own type, so nested values like `protocols.amqp.uri` and non-string leaves like `protocols.amqp.ssl` are reachable. Passing the keys separately means every key is addressable, including one containing a dot such as `jdbc.url`. (#23)
+- `Service.CredentialPath("protocols.amqp.uri")` is the dot-delimited form of the same lookup. It cannot address a key that itself contains a dot — use `Credential` for those.
+
+[BugFixes]
+- Pinned the credentials payload from #11, whose nested object once panicked the decoder, as a regression test. The defect was already fixed; the test keeps it fixed.

--- a/service.go
+++ b/service.go
@@ -30,6 +30,57 @@ func (s *Service) CredentialString(key string) (string, bool) {
 	return credential, ok
 }
 
+// Credential walks the credentials one key at a time and returns the value at
+// the end of the path, whatever its type: a string, a bool, the float64 a JSON
+// number decodes to, or a nested map or slice.
+//
+// Passing the keys separately means every key is addressable, including one
+// that contains a dot:
+//
+//	uri, ok := service.Credential("protocols", "amqp", "uri")
+//	url, ok := service.Credential("jdbc.url")
+//
+// It reports false if any key along the path is absent, if the path descends
+// through a value that is not a nested object, or if no keys are given.
+func (s *Service) Credential(keys ...string) (interface{}, bool) {
+	if len(keys) == 0 {
+		return nil, false
+	}
+
+	var current interface{} = s.Credentials
+
+	for _, key := range keys {
+		object, isObject := current.(map[string]interface{})
+		if !isObject {
+			return nil, false
+		}
+
+		value, exists := object[key]
+		if !exists {
+			return nil, false
+		}
+
+		current = value
+	}
+
+	return current, true
+}
+
+// CredentialPath is Credential addressed by a single dot-delimited path:
+//
+//	uri, ok := service.CredentialPath("protocols.amqp.uri")
+//
+// Because the path is split on every dot, it cannot address a key that itself
+// contains one — CredentialPath("jdbc.url") looks for "url" inside "jdbc" and
+// reports false. Use Credential for those keys.
+func (s *Service) CredentialPath(path string) (interface{}, bool) {
+	if path == "" {
+		return nil, false
+	}
+
+	return s.Credential(strings.Split(path, ".")...)
+}
+
 // Services is an association of service labels to a slice of services with that
 // label.
 type Services map[string][]Service


### PR DESCRIPTION
## Nested credential access (#23, #11)

`CredentialString` does a single top-level lookup and asserts the value is a
string, so a credential like `protocols.amqp.uri` was unreachable and a
non-string leaf like `protocols.amqp.ssl` returned `false`.

- **`Service.Credential(keys ...string) (interface{}, bool)`** walks the
  credentials one key at a time and returns the value with its own type —
  string, bool, the `float64` a JSON number decodes to, or a nested map or
  slice.
- **`Service.CredentialPath("protocols.amqp.uri")`** is the dot-delimited form,
  built on `Credential`.

Keys are passed separately in the primitive because `VCAP_SERVICES` credentials
are broker-defined free-form JSON and a key may itself contain a dot — `jdbc.url`
is a common one. The dotted form splits on every dot and so cannot address those;
the doc comment states the limitation and points at `Credential`.

`CredentialString` is deliberately untouched: making it path-aware would silently
change behavior for any existing caller whose key contains a dot.

Issue #11 needed no code — its payload decodes cleanly today, since `Credentials`
is `map[string]interface{}`. That payload is pinned as a regression test.

**API impact** — `gorelease -base=v1.19.1`:

```
## compatible changes
(*Service).Credential: added
(*Service).CredentialPath: added

# summary
Suggested version: v1.20.0
```

Purely additive; no existing signature or behavior altered.

## actionlint

Workflow files are executable configuration, and YAML validity says nothing about
whether they run. Last release cycle a duplicate `env:` key made CI parse to zero
jobs. `make actionlint` catches that class, auto-installing on demand the way
`mk/security.mk` does for govulncheck and gosec.

It is wired into `make check` **and** listed as its own step in the CI quality-gates
job — that job runs the gates individually rather than calling `make check`, because
golangci-lint comes from the action instead of `make lint`.

## Verification

- `make check` clean, `make test-race` passes
- coverage 89.4% → 90.9%

Closes #23
Closes #11