### PR TITLE
Capture the binding metadata CF sends

### DIFF
--- a/cfenv_test.go
+++ b/cfenv_test.go
@@ -374,6 +374,69 @@ func testcfenv(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	// Issue #25: everything CF puts in a binding object should survive the
+	// decode. A user-provided instance carries a syslog drain URL, and a
+	// named binding has an instance name distinct from its binding name.
+	when("binding metadata", func() {
+		var service *cfenv.Service
+
+		it.Before(func() {
+			env, err := cfenv.New(map[string]string{
+				"VCAP_APPLICATION": "{}",
+				"VCAP_SERVICES": `{"user-provided":[{
+					"binding_guid":"bd0f0b8a-2a4e-4b1e-9a4f-6f1a2c3d4e5f",
+					"binding_name":"my-binding",
+					"instance_guid":"1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+					"instance_name":"my-ups",
+					"name":"my-binding",
+					"label":"user-provided",
+					"tags":["logging"],
+					"credentials":{"url":"https://example.com"},
+					"syslog_drain_url":"syslog://logs.example.com:514"
+				}]}`,
+			})
+			Expect(err).To(BeNil())
+
+			service, err = env.Services.WithName("my-binding")
+			Expect(err).To(BeNil())
+		})
+
+		it("captures the syslog drain URL", func() {
+			Expect(service.SyslogDrainURL).To(Equal("syslog://logs.example.com:514"))
+		})
+
+		it("captures the instance identity", func() {
+			Expect(service.InstanceGUID).To(Equal("1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d"))
+			Expect(service.InstanceName).To(Equal("my-ups"))
+		})
+
+		it("captures the binding identity", func() {
+			Expect(service.BindingGUID).To(Equal("bd0f0b8a-2a4e-4b1e-9a4f-6f1a2c3d4e5f"))
+			Expect(service.BindingName).To(Equal("my-binding"))
+		})
+
+		it("keeps the instance name distinct from the binding name", func() {
+			Expect(service.Name).To(Equal("my-binding"))
+			Expect(service.InstanceName).To(Equal("my-ups"))
+		})
+
+		it("leaves the new fields empty when CF omits them", func() {
+			env, err := cfenv.New(map[string]string{
+				"VCAP_APPLICATION": "{}",
+				"VCAP_SERVICES":    `{"sendgrid":[{"name":"mysendgrid","label":"sendgrid","plan":"free","credentials":{}}]}`,
+			})
+			Expect(err).To(BeNil())
+
+			plain, err := env.Services.WithName("mysendgrid")
+			Expect(err).To(BeNil())
+			Expect(plain.SyslogDrainURL).To(Equal(""))
+			Expect(plain.InstanceGUID).To(Equal(""))
+			Expect(plain.InstanceName).To(Equal(""))
+			Expect(plain.BindingGUID).To(Equal(""))
+			Expect(plain.BindingName).To(Equal(""))
+		})
+	})
+
 	// Issue #11: a credential whose value was a nested object once panicked
 	// the decoder, which expected every credential to be a string. Pins the
 	// payload from that report so the fix cannot silently regress.

--- a/changelog.d/0001-adopt-changelog-fragments.md
+++ b/changelog.d/0001-adopt-changelog-fragments.md
@@ -1,3 +1,0 @@
-[Chores]
-- Release notes are now assembled from per-PR `changelog.d/` fragments into the annotated tag body, so cutting a release no longer requires hand-editing a notes file. `CHANGELOG.md` is removed; notes for v1.19.1 and earlier remain in the GitHub releases.
-- The CI security job installs gitleaks with `make install-gitleaks` — a pinned, checksum-verified download from the shared make snippets — replacing the download step that was inlined in the workflow.

--- a/changelog.d/0001-binding-metadata.md
+++ b/changelog.d/0001-binding-metadata.md
@@ -1,0 +1,2 @@
+[Features]
+- `Service` now captures the binding metadata Cloud Foundry sends but the decoder previously discarded: `SyslogDrainURL`, `InstanceGUID`, `InstanceName`, `BindingGUID` and `BindingName`. `SyslogDrainURL` is what `cf cups -l` sets on a user-provided instance, and `InstanceName` recovers the instance name for a named binding, where `Name` holds the binding name instead. (#25)

--- a/changelog.d/0002-add-actionlint-target.md
+++ b/changelog.d/0002-add-actionlint-target.md
@@ -1,2 +1,0 @@
-[Chores]
-- Added a `make actionlint` target that lints the GitHub Actions workflow files, auto-installing actionlint on demand. It is part of `make check` and runs as its own step in the CI quality-gates job.

--- a/changelog.d/0003-nested-credentials.md
+++ b/changelog.d/0003-nested-credentials.md
@@ -1,6 +1,0 @@
-[Features]
-- `Service.Credential(keys ...string)` reads a credential at any depth and returns it with its own type, so nested values like `protocols.amqp.uri` and non-string leaves like `protocols.amqp.ssl` are reachable. Passing the keys separately means every key is addressable, including one containing a dot such as `jdbc.url`. (#23)
-- `Service.CredentialPath("protocols.amqp.uri")` is the dot-delimited form of the same lookup. It cannot address a key that itself contains a dot — use `Credential` for those.
-
-[BugFixes]
-- Pinned the credentials payload from #11, whose nested object once panicked the decoder, as a regression test. The defect was already fixed; the test keeps it fixed.

--- a/service.go
+++ b/service.go
@@ -16,12 +16,18 @@ import (
 // service object contains a child object for each service instance of that
 // service that is bound to the application.
 type Service struct {
-	Name         string                 // name of the service
-	Label        string                 // label of the service
+	Name         string                 // the binding name if the binding has one, otherwise the instance name
+	Label        string                 // name of the service offering; "user-provided" for a user-provided instance
 	Tags         []string               // tags for the service
 	Plan         string                 // plan of the service
 	Credentials  map[string]interface{} // credentials for the service
 	VolumeMounts []map[string]string    `mapstructure:"volume_mounts"` // volume mount info as provided by the nfsbroker
+
+	SyslogDrainURL string `mapstructure:"syslog_drain_url"` // where the service wants app logs streamed; set by `cf cups -l`
+	InstanceGUID   string `mapstructure:"instance_guid"`    // GUID of the service instance
+	InstanceName   string `mapstructure:"instance_name"`    // name the user gave the service instance
+	BindingGUID    string `mapstructure:"binding_guid"`     // GUID of the service binding
+	BindingName    string `mapstructure:"binding_name"`     // name the user gave the binding, if any
 }
 
 func (s *Service) CredentialString(key string) (string, bool) {


### PR DESCRIPTION
Closes #25.

## The actual gap

The literal question in #25 — "can I read the user-provided env?" — was already
answered by existing behavior:

- User-provided **service instances** arrive in `VCAP_SERVICES` under the
  `user-provided` label, so `Services.WithLabel("user-provided")`, `WithName`
  and `WithTag` have always resolved them.
- Env vars set with `cf set-env` are ordinary process environment, already
  returned by `CurrentEnv()`.

What was genuinely broken is next door: `VCAP_SERVICES` carries eleven fields
per binding object and the decoder kept six, silently discarding the rest.

| Field | Before | After |
|---|---|---|
| `name`, `label`, `tags`, `plan`, `credentials`, `volume_mounts` | kept | kept |
| `syslog_drain_url` | **dropped** | `SyslogDrainURL` |
| `instance_guid`, `instance_name` | **dropped** | `InstanceGUID`, `InstanceName` |
| `binding_guid`, `binding_name` | **dropped** | `BindingGUID`, `BindingName` |

`syslog_drain_url` is the one a user-provided instance depends on — it is what
`cf cups -l` sets. And `instance_name` matters because `name` holds the *binding*
name when a binding has one, so without it there was no way to recover the
instance name for a named binding.

## Implementation note

`mapstructure` does not map snake_case onto CamelCase by itself — verified by
adding the fields untagged first and watching four of the five stay empty. Each
field therefore carries an explicit tag, as `volume_mounts` already did.

The `Name` and `Label` doc comments were corrected while here: `Name` is the
binding name if the binding has one and otherwise the instance name, and `Label`
is the service offering name, which is `user-provided` for a user-provided
instance.

## API impact

`gorelease -base=v1.20.0`:

```
## compatible changes
Service.BindingGUID: added
Service.BindingName: added
Service.InstanceGUID: added
Service.InstanceName: added
Service.SyslogDrainURL: added

# summary
Suggested version: v1.21.0
```

Purely additive.

## Verification

- `make check` clean, `make test-race` passes
- coverage 90.9% -> 91.0%
- new tests cover a fully-populated user-provided binding and a plain binding
  where CF omits every new field

Also carries the `changelog.d` sweep for the fragments v1.20.0 consumed.