### PR TITLE
Write down the testing policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,22 @@ If you’d like to have someone review the agreement before signing, you may dow
 - [Individual Contributor License Agreement](https://www.cloudfoundry.org/wp-content/uploads/icla.pdf)
 - [Corporate Contributor License Agreement](https://www.cloudfoundry.org/wp-content/uploads/ccla.pdf)
 
+**Testing policy**
+
+New functionality must arrive with tests covering it, and a bug fix must arrive
+with a test that fails without the fix. That second half matters more than it
+sounds: a test written after the fix proves only that the code does what it
+does, never that it catches the bug.
+
+`make check` and `make test-race` must both pass before a pull request is
+merged, and CI enforces both on every pull request. Run `make cover` to see
+where a change leaves coverage.
+
+Parsing changes deserve a look at `make fuzz` as well. `VCAP_APPLICATION` and
+`VCAP_SERVICES` come from the platform and from bound service brokers rather
+than from the application, so this package is a trust boundary: it must return
+an error or a value for any input, and never panic.
+
 **Interim versions**
 
 Work is reviewable between releases, not only at release time. Every change

--- a/changelog.d/0002-testing-policy.md
+++ b/changelog.d/0002-testing-policy.md
@@ -1,0 +1,2 @@
+[Chores]
+- Documented the project's testing policy in `CONTRIBUTING.md`: new functionality arrives with tests, a bug fix arrives with a test that fails without it, and `make check` plus `make test-race` gate every pull request. The practice was already followed; it was not written down. (#39)


### PR DESCRIPTION
Addresses the `test_policy` criterion in #39:

> The project MUST have a general policy (formal or not) that as major new
> functionality is added to the software produced by the project, tests of that
> functionality should be added to an automated test suite.

The practice was already followed — every feature in v1.20.0 through v1.22.0
shipped with tests and coverage rose from 89.4% to 93.6% — but it was never
written down. A contributor had to infer it, and the criterion had nothing to
point at.

## What the policy says

- New functionality arrives with tests covering it.
- **A bug fix arrives with a test that fails without the fix.** Called out
  explicitly because it is the part that is easy to get wrong: a test written
  after the fix proves the code does what it does, not that it catches the bug.
- `make check` and `make test-race` must both pass before merge; CI enforces
  both. `make cover` shows where a change leaves coverage.
- Parsing changes deserve `make fuzz`. `VCAP_APPLICATION` and `VCAP_SERVICES`
  come from the platform and from bound brokers rather than from the
  application, so this package is a trust boundary: it must return an error or a
  value for any input, and never panic.

## Scope

Documentation only — no code, no build changes. `make check` clean.

Note this now brings three `changelog.d` fragments pending for the next release
(the v1.23.0 sweep, interim versions, and this one).