### PR TITLE
Show the OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/cloudfoundry-community/go-cfenv/actions/workflows/ci.yml/badge.svg)](https://github.com/cloudfoundry-community/go-cfenv/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/cloudfoundry-community/go-cfenv/codeql.yml?label=CodeQL)](https://github.com/cloudfoundry-community/go-cfenv/security/code-scanning)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cloudfoundry-community/go-cfenv/badge)](https://scorecard.dev/viewer/?uri=github.com/cloudfoundry-community/go-cfenv)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13896/badge)](https://www.bestpractices.dev/projects/13896)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/cloudfoundry-community/go-cfenv)](go.mod)
 [![Latest Release](https://img.shields.io/github/v/release/cloudfoundry-community/go-cfenv)](https://github.com/cloudfoundry-community/go-cfenv/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)

--- a/changelog.d/0003-openssf-badge.md
+++ b/changelog.d/0003-openssf-badge.md
@@ -1,0 +1,2 @@
+[Chores]
+- Added the OpenSSF Best Practices badge to the README. The project is registered as entry 13896; the badge links to the self-certification and reports its current level. Scorecard reads this badge from the README, so its `CII-Best-Practices` check was scoring 0 while the entry existed but went uncited. (#39)


### PR DESCRIPTION
Addresses the `CII-Best-Practices` check in #39.

The project is registered on bestpractices.dev as entry
[13896](https://www.bestpractices.dev/projects/13896), but nothing in the
repository pointed at it. Scorecard reads the badge **from the README**, so that
check scored 0 despite the self-certification existing and being most of the way
complete.

```markdown
[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13896/badge)](https://www.bestpractices.dev/projects/13896)
```

Placed beside the Scorecard badge, since the two report on the same subject from
different angles.

## It self-labels, and self-updates

The badge is generated server-side and states its own level. Right now it
renders:

```
openssf best practices | in progress 91%
```

so it cannot overstate the project's status while the questionnaire is being
completed. As the remaining criteria are answered it moves on its own and
eventually flips to `passing` — no further change to this file.

## Note on timing

Scorecard re-runs on its own schedule rather than on merge, so the
`CII-Best-Practices` score will move a day or two after this lands, not
immediately.