### PR TITLE
Pin workflow actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,15 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
 
-  # Workflow actions do not update themselves.
+  # Workflow actions do not update themselves. They are pinned to commit
+  # SHAs, which makes every upstream release an update rather than only
+  # major bumps — grouped so they arrive as one weekly PR instead of one
+  # PR per action.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     name: Build at go directive floor
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.25"
       - run: go build ./...
@@ -31,10 +31,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
       - run: make test-race
@@ -44,13 +44,13 @@ jobs:
     name: Quality gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
           args: --timeout=5m
@@ -69,13 +69,13 @@ jobs:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # gitleaks scans git history, so a depth-1 checkout would leave it
           # inspecting a single commit and reporting clean regardless.
           fetch-depth: 0
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
       # govulncheck, gosec and modrot are go install'ed on demand by

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,18 +21,18 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: go
           build-mode: autobuild
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:go"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,18 +20,18 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Run analysis
-        # Pinned to a full patch tag: this action publishes no floating `v2`
-        # major tag, so `@v2` fails to resolve and the workflow never runs.
-        uses: ossf/scorecard-action@v2.4.4
+        # This action publishes no floating `v2` major tag — only full patch
+        # tags exist, which is why the version comment names one.
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif

--- a/changelog.d/0001-interim-versions.md
+++ b/changelog.d/0001-interim-versions.md
@@ -1,2 +1,0 @@
-[Chores]
-- Re-vendored `mk/bump.mk`, which no longer produces a prerelease that sorts before the release it follows. Applying a label to a final version gave `v1.23.0-dev.1` after `v1.23.0` — older than its own release, and unselectable by any resolver. The core now advances first, by `BUMP_PRERELEASE_STEP` (default `minor`, which matches this project's cadence), so `make bump dev` yields `v1.24.0-dev.1`. This is what lets interim versions be published for review between releases, satisfying the OpenSSF Best Practices `repo_interim` criterion. (#39)

--- a/changelog.d/0001-pin-actions.md
+++ b/changelog.d/0001-pin-actions.md
@@ -1,0 +1,4 @@
+[Chores]
+- Workflow actions are now pinned to full commit SHAs with the release
+  version as a trailing comment. Dependabot keeps updating SHA pins, and
+  its action bumps now arrive grouped as a single weekly PR.

--- a/changelog.d/0002-testing-policy.md
+++ b/changelog.d/0002-testing-policy.md
@@ -1,2 +1,0 @@
-[Chores]
-- Documented the project's testing policy in `CONTRIBUTING.md`: new functionality arrives with tests, a bug fix arrives with a test that fails without it, and `make check` plus `make test-race` gate every pull request. The practice was already followed; it was not written down. (#39)

--- a/changelog.d/0003-openssf-badge.md
+++ b/changelog.d/0003-openssf-badge.md
@@ -1,2 +1,0 @@
-[Chores]
-- Added the OpenSSF Best Practices badge to the README. The project is registered as entry 13896; the badge links to the self-certification and reports its current level. Scorecard reads this badge from the README, so its `CII-Best-Practices` check was scoring 0 while the entry existed but went uncited. (#39)


### PR DESCRIPTION
Pins every workflow `uses:` reference (16 across `ci.yml`, `codeql.yml`, `scorecard.yml`) to a full commit SHA, with the release version as a trailing comment — the format Dependabot reads and rewrites, so updates keep flowing.

| action | pinned at | version |
|---|---|---|
| `actions/checkout` | `3d3c42e5` | v7.0.1 |
| `actions/setup-go` | `b7ad1dad` | v7.0.0 |
| `github/codeql-action/*` | `f205ea1c` | v4.37.4 |
| `golangci/golangci-lint-action` | `ba0d7d2e` | v9.3.0 |
| `ossf/scorecard-action` | `2d114668` | v2.4.4 |

Each SHA is the peeled target of the tag the workflow previously floated on, so this changes *which commit runs* not at all — only whether upstream can move it later.

**Churn control:** SHA pins turn every upstream release into an update rather than only major bumps, so `dependabot.yml` gains a `groups:` stanza collapsing all action bumps into one weekly PR.

**Why reverse the earlier tag-pin decision:** the 16 resulting Scorecard findings sat permanently open as medium-severity code-scanning alerts, burying anything new that lands on that tab. This resolves the `Pinned-Dependencies` half of #45 (expected 0 → 10 on the next Scorecard run, auto-closing those alerts); the `Code-Review` half remains.

Verified locally: `make actionlint` and `make changelog-check` pass; zizmor reports zero findings (previously 16 `unpinned-uses`).

Also carries the v1.24.0 fragment sweep commit, riding along with the next PR as `make changelog-sweep` instructs.
