### PR TITLE
Refresh vendored build tooling from upstream

### DIFF
--- a/changelog.d/0001-pin-actions.md
+++ b/changelog.d/0001-pin-actions.md
@@ -1,4 +1,0 @@
-[Chores]
-- Workflow actions are now pinned to full commit SHAs with the release
-  version as a trailing comment. Dependabot keeps updating SHA pins, and
-  its action bumps now arrive grouped as a single weekly PR.

--- a/changelog.d/0001-vendor-refresh.md
+++ b/changelog.d/0001-vendor-refresh.md
@@ -1,0 +1,5 @@
+[Chores]
+- Refreshed the vendored build tooling: `make publish` now resolves the
+  tag that exists rather than deriving the next one, the deletion verbs
+  require an explicit tag, and dependency bumps landed since the last
+  release can be drafted into release notes with `make changelog-deps`.

--- a/mk/bump.mk
+++ b/mk/bump.mk
@@ -29,6 +29,10 @@
 #                        BUMP_PRERELEASE_STEP := patch
 #                      Only applies coming from a final version; counter
 #                      advances and label switches leave the core alone.
+#   BUMP_TAG_MATCH     Glob selecting the tag family to bump from, and it
+#                      must select exactly one family — see the note at
+#                      the definition. Default: v[0-9]*
+#                      Repos tagging v-X.Y.Z set: v-[0-9]*
 #   BUMP_BASE_CMD      Command printing the persisted CURRENT version
 #                      (not version.mk's "next release" resolution —
 #                      bumping that would double-increment). Default:
@@ -37,7 +41,10 @@
 #                      of bumps on one commit (bump dev, bump dev)
 #                      advance correctly, which `git describe` cannot
 #                      do with several tags on the same commit. A
-#                      leading 'v' is preserved onto the new version.
+#                      leading 'v' or 'v-' is preserved onto the new
+#                      version; 'v-' is matched first, since 'v*' also
+#                      matches a 'v-' base and would leave a stray '-'
+#                      that then reads as a prerelease separator.
 #                      No tag at all bumps from 0.0.0. File-versioned
 #                      repos point this at their file, e.g.:
 #                        BUMP_BASE_CMD := cat VERSION
@@ -57,9 +64,29 @@ _HIDE ?= _
 
 BUMP_LABELS       ?= dev alpha beta rc
 BUMP_PRERELEASE_STEP ?= minor
+# Glob selecting the tag family this repo releases under. The candidate
+# list must hold ONE family, because --sort=v:refname is versioncmp over
+# the whole refname -- a natural-order string compare, not a semver one.
+# It never strips the prefix, so it groups by prefix byte before it ever
+# compares versions: every 'v*' outranks every 'v-*', and 'v-3.0.0' sorts
+# below 'v2.0.1'. It also ranks a prerelease ABOVE its release unless
+# versionsort.prereleaseSuffix is configured.
+#
+# That only decides ties, since creatordate is primary -- but ties are
+# routine: a lightweight tag has no creation date of its own, so it
+# inherits the commit's, and every lightweight tag on one commit ties.
+# A repo migrating to 'v-' typically backfills 'v-X.Y.Z' beside the
+# legacy 'vX.Y.Z' on the same commit, which is exactly that case: the
+# tiebreak picks the legacy tag and the next bump silently lands back on
+# a tag Go refuses to resolve.
+#
+# Repos on the v- scheme set:  BUMP_TAG_MATCH := v-[0-9]*
+# Left at the default there, no tag matches and the bump starts from
+# 0.0.0 -- wrong, but loudly wrong, which beats the silent wrong answer.
+BUMP_TAG_MATCH    ?= v[0-9]*
 # Last --sort key is primary: creation date desc, version-aware refname
 # desc as the same-second tiebreak.
-BUMP_BASE_CMD     ?= git tag --merged HEAD --sort=-v:refname --sort=-creatordate 2>/dev/null | head -n 1
+BUMP_BASE_CMD     ?= git tag --merged HEAD --sort=-v:refname --sort=-creatordate '$(BUMP_TAG_MATCH)' 2>/dev/null | head -n 1
 VERSION_WRITE_CMD ?= git tag -a -m Bumped
 
 $(_HIDE)BUMP_MOD := $(filter major minor patch final $(BUMP_LABELS),$(MAKECMDGOALS))
@@ -80,7 +107,10 @@ bump:
 		exit 1; \
 	fi
 	@base=$$($(BUMP_BASE_CMD)); base=$${base:-0.0.0}; \
-	prefix=; case "$$base" in v*) prefix=v; base=$${base#v} ;; esac; \
+	prefix=; case "$$base" in \
+		v-*) prefix=v-; base=$${base#v-} ;; \
+		v*)  prefix=v;  base=$${base#v}  ;; \
+	esac; \
 	base=$${base%%+*}; \
 	core=$${base%%-*}; \
 	pre=; case "$$base" in *-*) pre=$${base#*-} ;; esac; \

--- a/mk/changelog.mk
+++ b/mk/changelog.mk
@@ -6,12 +6,30 @@
 #                            layout on stdout (empty when there are none)
 #   make changelog-sweep     git rm the fragments after a release
 #   make changelog-check     Fail if any fragment is malformed or a stub
+#   make changelog-deps      Draft the dependency fragment from the bot's
+#                            commits since the last release tag
+#   make changelog-deps-check  Report how many of those have landed, and
+#                            warn when no fragment mentions any
 #
 # Settings:
 #   CHANGELOG_DIR       Fragment directory. Default: changelog.d
 #   CHANGELOG_SLUG      Slug for changelog-new. Default: current branch.
 #   CHANGELOG_SECTIONS  Section names, in published order, '|'-separated.
 #                       Default: Breaking Changes|Features|BugFixes|Chores|Security Updates
+#   CHANGELOG_DEPS_GREP    Commit-subject pattern identifying a dependency
+#                       bump (POSIX basic regex). Default: ^chore(deps
+#   CHANGELOG_DEPS_SINCE   Start of the release window. Default: the
+#                       nearest 'vX.Y.Z' or 'v-X.Y.Z' tag, i.e. the last
+#                       release. Both forms are matched: a repo whose
+#                       major version has outrun its Go module path tags
+#                       releases 'v-X.Y.Z', because Go refuses to resolve
+#                       a 'vN.Y.Z' tag for N>=2 without a matching '/vN'
+#                       module path, but never version-parses the 'v-'
+#                       form. Matching only 'v[0-9]*' there would find no
+#                       tag and silently widen the window to the entire
+#                       history rather than the last release.
+#   CHANGELOG_DEPS_SLUG    Slug for changelog-deps. Default: dependency-updates
+#   CHANGELOG_DEPS_SECTION Section the draft is filed under. Default: Chores
 #
 # Why fragments instead of one CHANGELOG file: a shared changelog is a
 # merge-conflict magnet, and a single file cannot be both a durable
@@ -37,7 +55,16 @@ CHANGELOG_DIR      ?= changelog.d
 CHANGELOG_SLUG     ?=
 CHANGELOG_SECTIONS ?= Breaking Changes|Features|BugFixes|Chores|Security Updates
 
-.PHONY: changelog-new changelog-assemble changelog-sweep changelog-check
+# The unbalanced '(' is deliberate and safe: this is a plain assignment, not
+# a $(call) argument, and git's --grep is a POSIX basic regex where '(' is a
+# literal. Do NOT "fix" it to \( — in a BRE that opens a group.
+CHANGELOG_DEPS_GREP    ?= ^chore(deps
+CHANGELOG_DEPS_SINCE   ?=
+CHANGELOG_DEPS_SLUG    ?= dependency-updates
+CHANGELOG_DEPS_SECTION ?= Chores
+
+.PHONY: changelog-new changelog-assemble changelog-sweep changelog-check \
+        changelog-deps changelog-deps-check
 
 # Fragments sort by their numeric prefix. LC_ALL=C keeps that stable
 # regardless of the caller's locale.
@@ -114,6 +141,68 @@ changelog-check:
 	done; \
 	$(MAKE) --no-print-directory changelog-assemble >/dev/null || rc=1; \
 	[ "$$rc" -eq 0 ] && echo "changelog.d: $$(echo "$$files" | wc -l | tr -d ' ') fragment(s) OK" || exit 1
+
+# ── Dependency updates ───────────────────────────────────────
+#
+# A bot that opens dependency PRs (Dependabot, Renovate) will never run
+# changelog-new, so its bumps reach a release only if someone writes them up
+# by hand — and nothing reports the omission until the notes come out thin.
+# These two targets read them out of the commit log instead, keyed on the
+# subject prefix the bot is configured to use. Pin that prefix in the bot's
+# config; if it drifts, the bumps silently stop being found.
+#
+# Both see only what has LANDED on this branch. A bump sitting in an open
+# PR is not counted.
+
+# Resolves $$range and $$subjects: the window, and the deduped bump subjects
+# in it with the prefix stripped, oldest first.
+$(_HIDE)CHANGELOG_DEPS_SCAN = \
+	since='$(CHANGELOG_DEPS_SINCE)'; \
+	[ -n "$$since" ] || since=$$(git describe --tags --match 'v[0-9]*' --match 'v-[0-9]*' --abbrev=0 2>/dev/null || true); \
+	range=$${since:+$$since..}HEAD; \
+	subjects=$$(git log --reverse --no-merges --format='%s' --grep='$(CHANGELOG_DEPS_GREP)' "$$range" -- 2>/dev/null \
+		| sed -E 's/^[^:]*: *(bump )?//I' \
+		| awk 'NF && !seen[$$0]++')
+
+# Writes a DRAFT, one bump per clause — rewrite it into prose before the
+# release. Filed under Chores because that is where dependency work belongs;
+# a security bump usually wants moving to [Security Updates] by hand.
+changelog-deps:
+	@set -e; \
+	$($(_HIDE)CHANGELOG_DEPS_SCAN); \
+	if [ -z "$$subjects" ]; then echo "$(CHANGELOG_DIR): no dependency bumps in $$range"; exit 0; fi; \
+	file=$$($(MAKE) --no-print-directory changelog-new CHANGELOG_SLUG='$(CHANGELOG_DEPS_SLUG)'); \
+	{ echo '[$(CHANGELOG_DEPS_SECTION)]'; \
+	  printf -- '- Dependency updates: %s.\n' "$$(echo "$$subjects" | paste -sd ';' - | sed 's/;/; /g')"; \
+	} > "$$file"; \
+	echo "$$file"; \
+	echo "Drafted from $$(echo "$$subjects" | wc -l | tr -d ' ') bump(s) in $$range - edit into prose before release." >&2
+
+# Prints the count unconditionally, so this doubles as an any-time status
+# command: "has enough dependency work piled up to be worth a build?" needs
+# answering between releases, not only at tag time.
+#
+# It warns rather than fails, and is deliberately not wired into
+# changelog-check. A hard error here would fire on pipeline fixes, docs-only
+# changes, reverts and the bumps themselves; a gate with that false-positive
+# rate gets routed around rather than obeyed.
+#
+# "Covered" is a loose text match, not an exact one against the subjects:
+# changelog-deps writes a draft meant to be rewritten, and prose that no
+# longer quotes the raw subjects would otherwise warn on every well-curated
+# release. The cost is that a dependency fragment left over from an
+# already-published window silences the report for the current one —
+# changelog-sweep after each release is what prevents that.
+changelog-deps-check:
+	@set -e; \
+	$($(_HIDE)CHANGELOG_DEPS_SCAN); \
+	n=$$(test -n "$$subjects" && echo "$$subjects" | wc -l | tr -d ' ' || echo 0); \
+	echo "$(CHANGELOG_DIR): $$n dependency bump(s) in $$range"; \
+	[ "$$n" -gt 0 ] || exit 0; \
+	files=$$($($(_HIDE)CHANGELOG_FIND)); \
+	if [ -n "$$files" ] && echo "$$files" | xargs grep -qiE 'depend|bump' 2>/dev/null; then exit 0; fi; \
+	echo "WARNING: none of them are mentioned in any fragment, so they will not" >&2; \
+	echo "         appear in the release notes. Draft them: make changelog-deps" >&2
 
 # Run after publishing. The removal is left staged-but-uncommitted so it
 # rides the next PR rather than requiring a direct push to the default

--- a/mk/go-release.mk
+++ b/mk/go-release.mk
@@ -96,8 +96,12 @@ $(foreach target,$(TARGETS),$(eval $(call $(_HIDE)release_target_impl,$(word 1,$
 
 # ── Release lifecycle (tag → publish / unpublish → untag) ─────
 # Settings:
-#   TAG          Release tag. Default: the version with build metadata
-#                stripped — tags are clean semver (vX.Y.Z[-prerelease]).
+#   TAG          Release tag. Explicitly set, it applies to every verb.
+#                Unset, each verb resolves what its intent needs: tag
+#                derives the NEXT version (build metadata stripped —
+#                tags are clean semver); publish takes the nearest
+#                EXISTING tag; untag/unpublish refuse to guess and
+#                require TAG= on the command line.
 #   TAG_REMOTE   Remote for tag/untag. Default: origin
 #   DRAFT        DRAFT=yes publishes a draft release.
 #   NOTES        Notes file for publish. Default: gh --generate-notes.
@@ -123,7 +127,13 @@ $(foreach target,$(TARGETS),$(eval $(call $(_HIDE)release_target_impl,$(word 1,$
 # gets fragment-derived notes with no extra arguments, and a repo using
 # neither is unaffected.
 
-TAG           ?= v$($(_HIDE)SEMVER_NOMETA)
+# TAG_PREFIX selects the tag naming scheme. 'v' is the historical default.
+# Set 'v-' in repos whose major version has outrun their Go module path:
+# Go version-parses a 'vN.Y.Z' tag and refuses it when N>=2 without a
+# matching '/vN' module path, but never version-parses 'v-N.Y.Z', so that
+# form stays resolvable as a `go get` revision. version.mk parses both.
+TAG_PREFIX    ?= v
+TAG           ?=
 TAG_REMOTE    ?= origin
 DRAFT         ?=
 NOTES         ?=
@@ -133,32 +143,53 @@ GH_ASSETS     ?= $(RELEASE_ROOT)/$(PROJECT)-*
 # Prefix that turns state-changing commands into echoes under DRYRUN=yes
 $(_HIDE)DRY := $(if $(filter yes,$(DRYRUN)),@echo "DRYRUN:" )
 
+# Per-verb tag resolution. tag CREATES the next release, so its default
+# derives the next version. publish operates on a tag that already
+# EXISTS — deriving "next" there is always one release ahead: the moment
+# tag has run, next-version points past the tag just created, and a bare
+# `make tag && make publish` aborts on --verify-tag having published
+# nothing. So publish defaults to the nearest existing tag instead,
+# resolved at recipe time (kept lazy) so it also sees a tag created
+# earlier in the same invocation. Both stay recursive on purpose — see
+# version.mk on why := would freeze pre-bump values.
+$(_HIDE)NEXT_TAG    = $(TAG_PREFIX)$($(_HIDE)SEMVER_NOMETA)
+$(_HIDE)LAST_TAG    = $(shell git describe --tags --abbrev=0 2>/dev/null)
+$(_HIDE)CREATE_TAG  = $(or $(TAG),$($(_HIDE)NEXT_TAG))
+$(_HIDE)PUBLISH_TAG = $(or $(TAG),$($(_HIDE)LAST_TAG))
+
 .PHONY: tag untag publish unpublish
 
 tag:
-	@case "$(TAG)" in v[0-9]*.[0-9]*.[0-9]*) ;; *) echo "ERROR: '$(TAG)' does not look like a release tag (vX.Y.Z[-prerelease])" >&2; exit 1;; esac
+	@case "$($(_HIDE)CREATE_TAG)" in v[0-9]*.[0-9]*.[0-9]*) ;; *) echo "ERROR: '$($(_HIDE)CREATE_TAG)' does not look like a release tag (vX.Y.Z[-prerelease])" >&2; exit 1;; esac
 ifeq ($(strip $(TAG_NOTES_CMD)),)
-	$($(_HIDE)DRY)git tag -a "$(TAG)" -m "Release $(TAG)"
+	$($(_HIDE)DRY)git tag -a "$($(_HIDE)CREATE_TAG)" -m "Release $($(_HIDE)CREATE_TAG)"
 else
 	@body=$$($(TAG_NOTES_CMD)) || { echo "ERROR: TAG_NOTES_CMD failed - refusing to tag" >&2; exit 1; }; \
 	if [ -z "$$body" ]; then \
-		echo "ERROR: TAG_NOTES_CMD produced no output - refusing to tag $(TAG) with empty release notes." >&2; \
+		echo "ERROR: TAG_NOTES_CMD produced no output - refusing to tag $($(_HIDE)CREATE_TAG) with empty release notes." >&2; \
 		echo "       Add a fragment (make changelog-new), or unset TAG_NOTES_CMD for an untitled release." >&2; \
 		exit 1; \
 	fi; \
 	$(if $(filter yes,$(DRYRUN)), \
-		printf 'DRYRUN: git tag -a %s -F - <<EOF\n%s\nEOF\n' "$(TAG)" "$$body", \
-		printf '%s\n\n%s\n' "Release $(TAG)" "$$body" | git tag -a "$(TAG)" -F -)
+		printf 'DRYRUN: git tag -a %s -F - <<EOF\n%s\nEOF\n' "$($(_HIDE)CREATE_TAG)" "$$body", \
+		printf '%s\n\n%s\n' "Release $($(_HIDE)CREATE_TAG)" "$$body" | git tag -a "$($(_HIDE)CREATE_TAG)" -F -)
 endif
-	$($(_HIDE)DRY)git push $(TAG_REMOTE) "refs/tags/$(TAG)"
+	$($(_HIDE)DRY)git push $(TAG_REMOTE) "refs/tags/$($(_HIDE)CREATE_TAG)"
 
+# Deletion verbs never guess: "whatever is newest" as a default is how a
+# typo removes the wrong release. Both demand an explicit TAG.
 untag:
+	@[ -n "$(TAG)" ] || { echo "ERROR: untag deletes a tag - name it: make untag TAG=vX.Y.Z" >&2; exit 1; }
 	@echo "Deleting tag $(TAG) locally and on $(TAG_REMOTE)..."
 	-$($(_HIDE)DRY)git tag -d "$(TAG)"
 	$($(_HIDE)DRY)git push $(TAG_REMOTE) --delete "refs/tags/$(TAG)"
 
 publish:
-	@TAG="$(TAG)"; \
+	@TAG="$($(_HIDE)PUBLISH_TAG)"; \
+	if [ -z "$$TAG" ]; then \
+		echo "ERROR: no tag to publish - create one with 'make tag' or pass TAG=vX.Y.Z" >&2; \
+		exit 1; \
+	fi; \
 	PRERELEASE=""; case "$$TAG" in *-alpha*|*-beta*|*-rc*) PRERELEASE="--prerelease";; esac; \
 	NOTESARG="--generate-notes"; \
 	$(if $(NOTES),NOTESARG="--notes-file $(NOTES)",\
@@ -169,6 +200,7 @@ publish:
 	$(if $(filter yes,$(DRYRUN)),echo "DRYRUN: $$*",echo "+ $$*"; "$$@")
 
 unpublish:
+	@[ -n "$(TAG)" ] || { echo "ERROR: unpublish deletes a release - name it: make unpublish TAG=vX.Y.Z" >&2; exit 1; }
 	@echo "Release to delete from GitHub:"
 	@gh release view "$(TAG)" --json tagName,name,isDraft,assets \
 		--jq '"  " + .tagName + "  (" + .name + ")" + (if .isDraft then "  [draft]" else "" end), (.assets[] | "    " + .name)'

--- a/mk/version.mk
+++ b/mk/version.mk
@@ -3,7 +3,7 @@
 # Drop this file into a repo unchanged and `include` it. Per-repo settings:
 #   VERSION       Override the version string entirely (user-settable).
 #   VERSION_CMD   Shell command that prints the version string. Default:
-#                 nearest git tag, leading 'v' stripped, patch incremented
+#                 nearest git tag, leading 'v' or 'v-' stripped, patch incremented
 #                 ("the next release"). Repos with their own source set it
 #                 before or after the include, e.g.:
 #                   VERSION_CMD := node -p "require('./package.json').version"
@@ -32,11 +32,18 @@
 _HIDE ?= _
 
 # ── Version ───────────────────────────────────────────────────
-# Default source: nearest tag, 'v' stripped, patch+1 ("next release").
+# Default source: nearest tag, prefix stripped, patch+1 ("next release").
 # Only plain x.y.z tags qualify; a prerelease/buildmeta tag produces no
 # output and falls through to 0.0.0-unknown — set VERSION or VERSION_CMD
 # for anything richer.
-VERSION_CMD ?= git describe --tags --abbrev=0 2>/dev/null | sed -e 's/^v//' | awk -F. 'NF==3 && $$3 ~ /^[0-9]+$$/ {print $$1"."$$2"."$$3+1}'
+#
+# Both 'vX.Y.Z' and 'v-X.Y.Z' are accepted. The 'v-' form exists because Go
+# refuses to resolve a 'vN.Y.Z' tag (N>=2) unless the module path carries a
+# matching '/vN' suffix; a non-semver tag name sidesteps that rule and stays
+# usable as a `go get` revision. Strip 'v-' before 'v' — reversed, the 'v'
+# rule eats the prefix and leaves a leading '-', which later reads as a
+# semver prerelease separator.
+VERSION_CMD ?= git describe --tags --abbrev=0 2>/dev/null | sed -e 's/^v-//' -e 's/^v//' | awk -F. 'NF==3 && $$3 ~ /^[0-9]+$$/ {print $$1"."$$2"."$$3+1}'
 
 # Lazy (=/?=) rather than immediate (:=) so consumers re-evaluate at recipe
 # execution time. Important for chains like `make bump dev build ...` where
@@ -46,10 +53,12 @@ VERSION_CMD ?= git describe --tags --abbrev=0 2>/dev/null | sed -e 's/^v//' | aw
 # input; SEMVER_* are the internal canonical values derived from it.
 VERSION ?= $(shell v=$$($(VERSION_CMD)); echo "$${v:-0.0.0-unknown}")
 
-# Strip leading 'v' for parsing; remember it so SEMVER_VERSION reassembles
-# byte-identical to the input.
-$(_HIDE)SEMVER_IN     = $(patsubst v%,%,$(VERSION))
-$(_HIDE)SEMVER_PREFIX = $(if $(filter v%,$(VERSION)),v,)
+# Strip the leading 'v' or 'v-' for parsing; remember which one so
+# SEMVER_VERSION reassembles byte-identical to the input. Both orderings
+# below test 'v-' first: 'v%' also matches a 'v-' input, so checking it
+# first would misclassify 'v-1.2.3' as prefix 'v' and leave '-1.2.3'.
+$(_HIDE)SEMVER_IN     = $(patsubst v%,%,$(patsubst v-%,%,$(VERSION)))
+$(_HIDE)SEMVER_PREFIX = $(if $(filter v-%,$(VERSION)),v-,$(if $(filter v%,$(VERSION)),v,))
 
 # Split buildmeta off first (everything after '+'), then prerelease
 # (everything after the first '-' of what remains), leaving the x.y.z core.


### PR DESCRIPTION
Refreshes the vendored `mk/` tooling from upstream GNUMakefile-Snippets main (`bump.mk`, `changelog.mk`, `go-release.mk`, `version.mk`; `help.mk` and `security.mk` were already current). Three improvements arrive:

1. **`make publish` resolves the tag that exists** instead of deriving the next version — a bare tag-then-publish previously computed one release ahead and aborted on `--verify-tag` having published nothing (hit live releasing v1.24.1). The deletion verbs (`untag`/`unpublish`) now require an explicit `TAG=` rather than guessing.
2. **`make changelog-deps` / `changelog-deps-check`** — drafts release-notes fragments from dependency bumps landed since the last release, and reports when bumps aren't covered by any fragment. Relevant here now that Dependabot's action updates arrive as one grouped weekly PR.
3. **`v-` tag-scheme support** (for majors that outrun the module path) — inert in this repo: a v1 module keeps plain `v` tags.

Verified against this repo's real tags:

```
make check test-race changelog-check   # all pass
make tag DRYRUN=yes                    # derives v1.24.2 (next)
make publish DRYRUN=yes                # resolves v1.24.1 (existing), --notes-from-tag
make unpublish                         # errors: name the tag explicitly
make changelog-deps-check              # 0 dependency bump(s) in v1.24.1..HEAD
make bump dev DRYRUN=yes               # v1.24.1 -> v1.25.0-dev.1
```

Also carries the v1.24.1 fragment-sweep commit, riding along with the next PR as `make changelog-sweep` instructs.
