### PR TITLE
Add changelog fragment for the CodeQL action bump

### DIFF
--- a/changelog.d/0002-actions-bump.md
+++ b/changelog.d/0002-actions-bump.md
@@ -1,0 +1,3 @@
+[Chores]
+- Bumped the pinned `github/codeql-action` used by the CodeQL and
+  Scorecard workflows from v4.37.4 to v4.37.7.


### PR DESCRIPTION
Adds a changelog.d fragment so the v1.24.2 release notes mention the `github/codeql-action` v4.37.4 → v4.37.7 bump that landed via the grouped Dependabot actions updates. Notes-only change; no code affected.